### PR TITLE
Add OP3 Podcast Analytics Dashboard with Multiple Layouts

### DIFF
--- a/op3/full.liquid
+++ b/op3/full.liquid
@@ -1,0 +1,13 @@
+<div class="view w--full h--full">
+  {% render "main",
+      IDX_0: IDX_0,
+      IDX_1: IDX_1,
+      trmnl: trmnl,
+      layout_size: "full",
+      showInstance: true %}
+</div>
+
+{% render "title_bar",
+    IDX_0: IDX_0,
+    trmnl: trmnl,
+    showInstance: true %}

--- a/op3/full.liquid
+++ b/op3/full.liquid
@@ -1,11 +1,9 @@
-<div class="view w--full h--full">
-  {% render "main",
-      IDX_0: IDX_0,
-      IDX_1: IDX_1,
-      trmnl: trmnl,
-      layout_size: "full",
-      showInstance: true %}
-</div>
+{% render "main",
+    IDX_0: IDX_0,
+    IDX_1: IDX_1,
+    trmnl: trmnl,
+    layout_size: "full",
+    showInstance: true %}
 
 {% render "title_bar",
     IDX_0: IDX_0,

--- a/op3/half-horizontal.liquid
+++ b/op3/half-horizontal.liquid
@@ -1,0 +1,13 @@
+<div class="view w--full h--full">
+  {% render "main",
+      IDX_0: IDX_0,
+      IDX_1: IDX_1,
+      trmnl: trmnl,
+      layout_size: "half-horizontal",
+      showInstance: true %}
+</div>
+
+{% render "title_bar",
+    IDX_0: IDX_0,
+    trmnl: trmnl,
+    showInstance: true %}

--- a/op3/half-horizontal.liquid
+++ b/op3/half-horizontal.liquid
@@ -1,11 +1,9 @@
-<div class="view w--full h--full">
-  {% render "main",
-      IDX_0: IDX_0,
-      IDX_1: IDX_1,
-      trmnl: trmnl,
-      layout_size: "half-horizontal",
-      showInstance: true %}
-</div>
+{% render "main",
+    IDX_0: IDX_0,
+    IDX_1: IDX_1,
+    trmnl: trmnl,
+    layout_size: "half-horizontal",
+    showInstance: true %}
 
 {% render "title_bar",
     IDX_0: IDX_0,

--- a/op3/half-vertical.liquid
+++ b/op3/half-vertical.liquid
@@ -1,0 +1,13 @@
+<div class="view w--full h--full">
+  {% render "main",
+      IDX_0: IDX_0,
+      IDX_1: IDX_1,
+      trmnl: trmnl,
+      layout_size: "half-vertical",
+      showInstance: false %}
+</div>
+
+{% render "title_bar",
+    IDX_0: IDX_0,
+    trmnl: trmnl,
+    showInstance: false %}

--- a/op3/half-vertical.liquid
+++ b/op3/half-vertical.liquid
@@ -1,11 +1,9 @@
-<div class="view w--full h--full">
-  {% render "main",
-      IDX_0: IDX_0,
-      IDX_1: IDX_1,
-      trmnl: trmnl,
-      layout_size: "half-vertical",
-      showInstance: false %}
-</div>
+{% render "main",
+    IDX_0: IDX_0,
+    IDX_1: IDX_1,
+    trmnl: trmnl,
+    layout_size: "half-vertical",
+    showInstance: false %}
 
 {% render "title_bar",
     IDX_0: IDX_0,

--- a/op3/quadrant.liquid
+++ b/op3/quadrant.liquid
@@ -1,0 +1,13 @@
+<div class="view w--full h--full">
+  {% render "main",
+      IDX_0: IDX_0,
+      IDX_1: IDX_1,
+      trmnl: trmnl,
+      layout_size: "quadrant",
+      showInstance: false %}
+</div>
+
+{% render "title_bar",
+    IDX_0: IDX_0,
+    trmnl: trmnl,
+    showInstance: false %}

--- a/op3/quadrant.liquid
+++ b/op3/quadrant.liquid
@@ -1,11 +1,9 @@
-<div class="view w--full h--full">
-  {% render "main",
-      IDX_0: IDX_0,
-      IDX_1: IDX_1,
-      trmnl: trmnl,
-      layout_size: "quadrant",
-      showInstance: false %}
-</div>
+{% render "main",
+    IDX_0: IDX_0,
+    IDX_1: IDX_1,
+    trmnl: trmnl,
+    layout_size: "quadrant",
+    showInstance: false %}
 
 {% render "title_bar",
     IDX_0: IDX_0,

--- a/op3/shared.liquid
+++ b/op3/shared.liquid
@@ -68,7 +68,8 @@ Parameters:
       var downloadsAll = [];
 
       {% for episode in episodes %}
-        episodeLabels.push("{{ episode.title | escape }}");
+        {% assign title = episode.title | truncate: 25, "..." %}
+        episodeLabels.push("{{ title | escape }}");
         downloads1d.push({{ episode.downloads1 | default: 0 }});
         downloads3d.push({{ episode.downloads3 | default: 0 }});
         downloads7d.push({{ episode.downloads7 | default: 0 }});
@@ -178,13 +179,11 @@ Parameters:
           labels: {
             style: {
               fontSize: "{% if layout_size == 'quadrant' %}10px{% elsif layout_size == 'half-vertical' %}12px{% else %}14px{% endif %}",
-              color: "#000000",
-              textOverflow: "none",
-              width: "{% if layout_size == 'quadrant' %}60px{% elsif layout_size == 'half-vertical' %}80px{% else %}120px{% endif %}"
+              color: "#000000"
             },
             padding: 5,
             y: 25,
-            rotation: {% if layout_size == 'quadrant' or layout_size == 'half-vertical' %}-45{% else %}-25{% endif %}
+            rotation: 0
           },
           lineWidth: 0,
           gridLineDashStyle: "dot",

--- a/op3/shared.liquid
+++ b/op3/shared.liquid
@@ -31,9 +31,8 @@ Parameters:
 <script src="https://usetrmnl.com/js/highcharts/12.3.0/highcharts.js"></script>
 <script src="https://usetrmnl.com/js/highcharts/12.3.0/pattern-fill.js"></script>
 
-<div class="view view--full">
-  <div class="layout layout--col gap--space-between">
-    <!-- Statistics cards -->
+<div class="layout layout--col gap--space-between">
+  <!-- Statistics cards -->
     <div class="grid {% if layout_size == 'full' or layout_size == 'half-horizontal' %}grid--cols-2{% else %}grid--cols-1{% endif %}">
       <div class="item">
         <div class="meta"></div>
@@ -188,6 +187,5 @@ Parameters:
         }
       });
     </script>
-  </div>
 </div>
 {% endtemplate %}

--- a/op3/shared.liquid
+++ b/op3/shared.liquid
@@ -68,8 +68,7 @@ Parameters:
       var downloadsAll = [];
 
       {% for episode in episodes %}
-        {% assign title = episode.title | truncate: 40, "..." %}
-        episodeLabels.push("{{ title | escape }}");
+        episodeLabels.push("{{ episode.title | escape }}");
         downloads1d.push({{ episode.downloads1 | default: 0 }});
         downloads3d.push({{ episode.downloads3 | default: 0 }});
         downloads7d.push({{ episode.downloads7 | default: 0 }});
@@ -179,8 +178,11 @@ Parameters:
           labels: {
             style: {
               fontSize: "{% if layout_size == 'quadrant' %}10px{% elsif layout_size == 'half-vertical' %}12px{% else %}14px{% endif %}",
-              color: "#000000"
+              color: "#000000",
+              textOverflow: "none",
+              whiteSpace: "nowrap"
             },
+            overflow: "allow",
             padding: 5,
             y: 25,
             rotation: {% if layout_size == 'quadrant' or layout_size == 'half-vertical' %}-45{% else %}0{% endif %}

--- a/op3/shared.liquid
+++ b/op3/shared.liquid
@@ -77,23 +77,27 @@ Parameters:
         downloadsAll.push({{ episode.downloadsAll | default: 0 }});
       {% endfor %}
 
-      // Format data for Highcharts
-      var chartData = [];
+      // Calculate incremental downloads for stacked chart
+      var data1d = [];
+      var data3to1d = [];
+      var data7to3d = [];
+      var dataAllto7d = [];
+
       for (var i = 0; i < episodeLabels.length; i++) {
-        chartData.push([episodeLabels[i], downloadsAll[i]]);
+        // First day downloads
+        data1d.push(downloads1d[i]);
+
+        // Downloads from day 1 to 3 (3d total minus 1d)
+        data3to1d.push(Math.max(0, downloads3d[i] - downloads1d[i]));
+
+        // Downloads from day 3 to 7 (7d total minus 3d)
+        data7to3d.push(Math.max(0, downloads7d[i] - downloads3d[i]));
+
+        // Downloads after day 7 (All total minus 7d)
+        dataAllto7d.push(Math.max(0, downloadsAll[i] - downloads7d[i]));
       }
 
-      var chartData7d = [];
-      for (var i = 0; i < episodeLabels.length; i++) {
-        chartData7d.push([episodeLabels[i], downloads7d[i]]);
-      }
-
-      var chartData30d = [];
-      for (var i = 0; i < episodeLabels.length; i++) {
-        chartData30d.push([episodeLabels[i], downloads30d[i]]);
-      }
-
-      // Initialize chart
+      // Initialize chart with stacked columns
       Highcharts.chart("op3-episode-chart", {
         chart: {
           type: "column",
@@ -106,26 +110,25 @@ Parameters:
           text: null
         },
         plotOptions: {
-          series: {
+          column: {
+            stacking: 'normal',
             animation: false,
             enableMouseTracking: false,
             states: {
               hover: { enabled: false }
             },
-            pointPadding: 0.05,
-            groupPadding: 0.1,
+            pointPadding: 0.1,
+            groupPadding: 0.2,
             borderWidth: 0
           }
         },
         series: [{
-          data: chartData,
-          color: "#000000",
-          name: "All Time",
-          zIndex: 3
+          name: "Day 1",
+          data: data1d,
+          color: "#000000"
         }, {
-          data: chartData30d,
-          name: "30 Days",
-          zIndex: 2,
+          name: "Days 1-3",
+          data: data3to1d,
           color: {
             pattern: {
               image: "https://usetrmnl.com/images/grayscale/gray-3.png",
@@ -134,12 +137,21 @@ Parameters:
             }
           }
         }, {
-          data: chartData7d,
-          name: "7 Days",
-          zIndex: 1,
+          name: "Days 3-7",
+          data: data7to3d,
           color: {
             pattern: {
               image: "https://usetrmnl.com/images/grayscale/gray-5.png",
+              width: 12,
+              height: 12
+            }
+          }
+        }, {
+          name: "After Day 7",
+          data: dataAllto7d,
+          color: {
+            pattern: {
+              image: "https://usetrmnl.com/images/grayscale/gray-7.png",
               width: 12,
               height: 12
             }
@@ -163,7 +175,7 @@ Parameters:
           }
         },
         xAxis: {
-          type: "category",
+          categories: episodeLabels,
           labels: {
             style: {
               fontSize: "{% if layout_size == 'quadrant' %}10px{% elsif layout_size == 'half-vertical' %}12px{% else %}14px{% endif %}",

--- a/op3/shared.liquid
+++ b/op3/shared.liquid
@@ -180,12 +180,11 @@ Parameters:
               fontSize: "{% if layout_size == 'quadrant' %}10px{% elsif layout_size == 'half-vertical' %}12px{% else %}14px{% endif %}",
               color: "#000000",
               textOverflow: "none",
-              whiteSpace: "nowrap"
+              width: "{% if layout_size == 'quadrant' %}60px{% elsif layout_size == 'half-vertical' %}80px{% else %}120px{% endif %}"
             },
-            overflow: "allow",
             padding: 5,
             y: 25,
-            rotation: {% if layout_size == 'quadrant' or layout_size == 'half-vertical' %}-45{% else %}0{% endif %}
+            rotation: {% if layout_size == 'quadrant' or layout_size == 'half-vertical' %}-45{% else %}-25{% endif %}
           },
           lineWidth: 0,
           gridLineDashStyle: "dot",

--- a/op3/shared.liquid
+++ b/op3/shared.liquid
@@ -1,0 +1,193 @@
+{% template title_bar %}
+<div class="title_bar">
+  <svg class="image image-stroke image--dither rounded--full" viewBox="0 0 24 24">
+    <path d="m11.936 2c-1.1206 0.0018117-2.2188 0.12471-3.2653 0.36557-3.1183 0.73218-5.5532 3.1697-6.2847 6.2911-0.51396 2.1933-0.51396 4.475 0 6.6684 0.73143 3.1214 3.1665 5.557 6.2847 6.2891 2.191 0.51445 4.4685 0.51445 6.6597 0 3.1184-0.73214 5.5533-3.1676 6.2847-6.2891 0.51393-2.1932 0.51393-4.4751 0-6.6684-0.73139-3.1214-3.1664-5.5588-6.2847-6.2911-1.1318-0.24812-2.2736-0.36738-3.3942-0.36557zm0.12304 1.0342c1.0408 0.0019 2.0624 0.11825 3.035 0.34212 2.7342 0.64198 4.87 2.7801 5.5113 5.5169 0.47747 2.0375 0.47747 4.1558 0 6.1933-0.64129 2.737-2.7773 4.875-5.5113 5.5169-2.0354 0.47796-4.1516 0.47796-6.187 0-2.7342-0.64194-4.87-2.7801-5.5113-5.5169-0.47745-2.0375-0.47745-4.1558 0-6.1933 0.64133-2.737 2.7773-4.875 5.5113-5.5169 1.0515-0.23147 2.1112-0.34402 3.1521-0.34212zm-3.0467 2.2072-3.0096 1.517s-0.00488 4.9557 0 7.4758c2.9533 1.4779 6.2357 3.12 9.0013 4.5042l2.9959-1.4994v-4.5003l-2.9959-1.4994v-1.4994l-2.9959-1.4994v-1.4994l-2.9959-1.4994zm0 0.84063 1.7519 0.87582-1.7519 0.90124-1.7519-0.90124zm-2.2478 1.4623 2.2478 1.1534v6.2011l-2.2478-1.1241zm5.2437 1.5366 1.7519 0.87582-1.7519 0.90124-1.7519-0.90124zm-2.2478 1.4623 2.2478 1.1534v3.3645c-0.0029 0.40982-0.0052 0.85478-0.0059 1.3353l-2.242-1.1222v-4.731zm5.2437 1.5366 1.7519 0.87582-1.7519 0.90124-1.7519-0.90124zm-2.2478 1.4623 2.2478 1.1534v3.2022l-2.2478-1.1241z"></path>
+  </svg>
+  <span class="title">{{ trmnl.plugin_settings.instance_name }}</span>
+  {% if showInstance %}
+  <span class="instance">{{ IDX_0.showTitle }}</span>
+  {% endif %}
+</div>
+{% endtemplate %}
+
+{% template main %}
+{% comment %}
+Main template for OP3 podcast analytics dashboard
+Parameters:
+- IDX_0: Episode data with downloads
+- IDX_1: Show download statistics
+- trmnl: TRMNL configuration
+- layout_size: 'full', 'half-horizontal', 'half-vertical', or 'quadrant'
+{% endcomment %}
+
+{% comment %} Extract statistics {% endcomment %}
+{% assign monthly_downloads = IDX_1.showDownloadCounts[IDX_0.showUuid].monthlyDownloads | default: 0 %}
+{% assign weekly_avg = IDX_1.showDownloadCounts[IDX_0.showUuid].weeklyAvgDownloads | default: 0 %}
+
+{% comment %} Prepare episode data for chart {% endcomment %}
+{% assign episodes = IDX_0.episodes | slice: 0, 5 %}
+
+<!-- Import Highcharts library -->
+<script src="https://usetrmnl.com/js/highcharts/12.3.0/highcharts.js"></script>
+<script src="https://usetrmnl.com/js/highcharts/12.3.0/pattern-fill.js"></script>
+
+<div class="view view--full">
+  <div class="layout layout--col gap--space-between">
+    <!-- Statistics cards -->
+    <div class="grid {% if layout_size == 'full' or layout_size == 'half-horizontal' %}grid--cols-2{% else %}grid--cols-1{% endif %}">
+      <div class="item">
+        <div class="meta"></div>
+        <div class="content">
+          <div class="w--14 h--1.5 mb--2 bg--black" style="border-radius: 20px;"></div>
+          <span class="value value--tnums">{{ monthly_downloads | round }}</span>
+          <span class="label">Monthly Downloads</span>
+        </div>
+      </div>
+      <div class="item">
+        <div class="meta"></div>
+        <div class="content">
+          <div class="w--14 h--1.5 mb--2 bg--gray-3"></div>
+          <span class="value value--tnums">{{ weekly_avg | round }}</span>
+          <span class="label">Weekly Average</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="border--h-5 w--full"></div>
+
+    <!-- Chart container -->
+    <div id="op3-episode-chart" class="w--full"></div>
+
+    <script type="text/javascript">
+      // Process episode data for chart
+      var episodeLabels = [];
+      var downloads1d = [];
+      var downloads3d = [];
+      var downloads7d = [];
+      var downloads30d = [];
+      var downloadsAll = [];
+
+      {% for episode in episodes %}
+        {% assign title = episode.title | truncate: 40, "..." %}
+        episodeLabels.push("{{ title | escape }}");
+        downloads1d.push({{ episode.downloads1 | default: 0 }});
+        downloads3d.push({{ episode.downloads3 | default: 0 }});
+        downloads7d.push({{ episode.downloads7 | default: 0 }});
+        downloads30d.push({{ episode.downloads30 | default: 0 }});
+        downloadsAll.push({{ episode.downloadsAll | default: 0 }});
+      {% endfor %}
+
+      // Format data for Highcharts
+      var chartData = [];
+      for (var i = 0; i < episodeLabels.length; i++) {
+        chartData.push([episodeLabels[i], downloadsAll[i]]);
+      }
+
+      var chartData7d = [];
+      for (var i = 0; i < episodeLabels.length; i++) {
+        chartData7d.push([episodeLabels[i], downloads7d[i]]);
+      }
+
+      var chartData30d = [];
+      for (var i = 0; i < episodeLabels.length; i++) {
+        chartData30d.push([episodeLabels[i], downloads30d[i]]);
+      }
+
+      // Initialize chart
+      Highcharts.chart("op3-episode-chart", {
+        chart: {
+          type: "column",
+          height: null,
+          width: null,
+          animation: false,
+          spacing: [10, 10, 5, 10]
+        },
+        title: {
+          text: null
+        },
+        plotOptions: {
+          series: {
+            animation: false,
+            enableMouseTracking: false,
+            states: {
+              hover: { enabled: false }
+            },
+            pointPadding: 0.05,
+            groupPadding: 0.1,
+            borderWidth: 0
+          }
+        },
+        series: [{
+          data: chartData,
+          color: "#000000",
+          name: "All Time",
+          zIndex: 3
+        }, {
+          data: chartData30d,
+          name: "30 Days",
+          zIndex: 2,
+          color: {
+            pattern: {
+              image: "https://usetrmnl.com/images/grayscale/gray-3.png",
+              width: 12,
+              height: 12
+            }
+          }
+        }, {
+          data: chartData7d,
+          name: "7 Days",
+          zIndex: 1,
+          color: {
+            pattern: {
+              image: "https://usetrmnl.com/images/grayscale/gray-5.png",
+              width: 12,
+              height: 12
+            }
+          }
+        }],
+        tooltip: { enabled: false },
+        legend: { enabled: false },
+        yAxis: {
+          labels: {
+            style: {
+              fontSize: "{% if layout_size == 'quadrant' %}12px{% else %}16px{% endif %}",
+              color: "#000000"
+            }
+          },
+          gridLineDashStyle: "shortdot",
+          gridLineWidth: 1,
+          gridLineColor: "#000000",
+          tickAmount: {% if layout_size == 'quadrant' or layout_size == 'half-vertical' %}3{% else %}5{% endif %},
+          title: {
+            text: null
+          }
+        },
+        xAxis: {
+          type: "category",
+          labels: {
+            style: {
+              fontSize: "{% if layout_size == 'quadrant' %}10px{% elsif layout_size == 'half-vertical' %}12px{% else %}14px{% endif %}",
+              color: "#000000"
+            },
+            padding: 5,
+            y: 25,
+            rotation: {% if layout_size == 'quadrant' or layout_size == 'half-vertical' %}-45{% else %}0{% endif %}
+          },
+          lineWidth: 0,
+          gridLineDashStyle: "dot",
+          tickWidth: 0,
+          tickLength: 0,
+          gridLineWidth: 1,
+          gridLineColor: "#000000",
+          title: {
+            text: null
+          }
+        },
+        credits: {
+          enabled: false
+        }
+      });
+    </script>
+  </div>
+</div>
+{% endtemplate %}

--- a/op3/shared.liquid
+++ b/op3/shared.liquid
@@ -31,8 +31,9 @@ Parameters:
 <script src="https://usetrmnl.com/js/highcharts/12.3.0/highcharts.js"></script>
 <script src="https://usetrmnl.com/js/highcharts/12.3.0/pattern-fill.js"></script>
 
-<div class="layout layout--col gap--space-between">
-  <!-- Statistics cards -->
+<div class="view view--full">
+  <div class="layout layout--col gap--space-between">
+    <!-- Statistics cards -->
     <div class="grid {% if layout_size == 'full' or layout_size == 'half-horizontal' %}grid--cols-2{% else %}grid--cols-1{% endif %}">
       <div class="item">
         <div class="meta"></div>
@@ -187,5 +188,6 @@ Parameters:
         }
       });
     </script>
+  </div>
 </div>
 {% endtemplate %}


### PR DESCRIPTION
## Summary
- Introduces a new OP3 podcast analytics dashboard feature
- Adds four layout variants: full, half-horizontal, half-vertical, and quadrant
- Displays monthly downloads, weekly average, and episode download charts
- Uses Highcharts for visualizing download statistics over different time periods

## Changes

### Templates
- Created new Liquid templates for each layout variant:
  - `full.liquid`
  - `half-horizontal.liquid`
  - `half-vertical.liquid`
  - `quadrant.liquid`
- Added a shared template `shared.liquid` containing reusable components:
  - `title_bar` for dashboard header with instance name and optional instance title
  - `main` template rendering statistics cards and episode download charts

### Dashboard Features
- Displays key metrics: monthly downloads and weekly average downloads
- Shows a column chart with episode download counts for all time, last 30 days, and last 7 days
- Chart is responsive to layout size with adjusted font sizes and tick amounts
- Uses Highcharts library loaded from CDN with pattern fills for visual distinction

## Test plan
- Verify each layout renders correctly with appropriate instance titles
- Confirm monthly and weekly download statistics display accurate values
- Check episode download chart renders with correct data and styling
- Ensure Highcharts scripts load and function without errors
- Validate responsiveness and layout adjustments for different dashboard sizes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ef68b554-c20e-4807-8b5c-93c0556bb877